### PR TITLE
use global thanos metrics and other changes

### DIFF
--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -192,7 +192,7 @@ func NewTSDBStores(
 		if cfg.IndexType == types.TSDBType {
 			var c client.ObjectClient
 			var err error
-			if storeCfg.ThanosObjStore {
+			if storeCfg.UseThanosObjstore {
 				c, err = baseStore.NewObjectClientV2(component, cfg.ObjectType, storeCfg)
 			} else {
 				c, err = baseStore.NewObjectClient(cfg.ObjectType, storeCfg, clientMetrics)

--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -188,13 +188,12 @@ func NewTSDBStores(
 		stores:    make([]TSDBStore, len(schemaCfg.Configs)),
 	}
 
-	metrics := &client.Metrics{Registerer: reg}
 	for i, cfg := range schemaCfg.Configs {
 		if cfg.IndexType == types.TSDBType {
 			var c client.ObjectClient
 			var err error
 			if storeCfg.ThanosObjStore {
-				c, err = baseStore.NewObjectClientV2(component, cfg.ObjectType, storeCfg, metrics)
+				c, err = baseStore.NewObjectClientV2(component, cfg.ObjectType, storeCfg)
 			} else {
 				c, err = baseStore.NewObjectClient(cfg.ObjectType, storeCfg, clientMetrics)
 			}

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -541,8 +541,7 @@ func GetObjectClient(store string, conf loki.Config, cm storage.ClientMetrics) (
 	var c chunk.ObjectClient
 	var err error
 	if conf.StorageConfig.ThanosObjStore {
-		metrics := &chunk.Metrics{Registerer: prometheus.DefaultRegisterer}
-		c, err = storage.NewObjectClientV2("log-cli-query", store, conf.StorageConfig, metrics)
+		c, err = storage.NewObjectClientV2("log-cli-query", store, conf.StorageConfig)
 	} else {
 		c, err = storage.NewObjectClient(store, conf.StorageConfig, cm)
 	}

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -540,7 +540,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 func GetObjectClient(store string, conf loki.Config, cm storage.ClientMetrics) (chunk.ObjectClient, error) {
 	var c chunk.ObjectClient
 	var err error
-	if conf.StorageConfig.ThanosObjStore {
+	if conf.StorageConfig.UseThanosObjstore {
 		c, err = storage.NewObjectClientV2("log-cli-query", store, conf.StorageConfig)
 	} else {
 		c, err = storage.NewObjectClient(store, conf.StorageConfig, cm)

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -59,8 +59,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Ring.RegisterFlagsWithPrefix("common.storage.", "collectors/", f)
 	c.Ring.RegisterFlagsWithPrefix("common.storage.", "collectors/", throwaway)
 
-	f.BoolVar(&c.Storage.ThanosObjStore, "common.thanos.enable", false, "Enable the thanos.io/objstore to be the backend for object storage")
-
 	// instance related flags.
 	c.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	throwaway.StringVar(&c.InstanceAddr, "common.instance-addr", "", "Default advertised address to be used by Loki components.")
@@ -81,8 +79,7 @@ type Storage struct {
 	Hedging           hedging.Config            `yaml:"hedging"`
 	COS               ibmcloud.COSConfig        `yaml:"cos"`
 	CongestionControl congestion.Config         `yaml:"congestion_control,omitempty"`
-	ThanosObjStore    bool                      `yaml:"thanos_objstore"`
-	ObjStoreConf      bucket.Config             `yaml:"objstore_config"`
+	ObjectStore       bucket.Config             `yaml:"object_store"`
 }
 
 func (s *Storage) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -97,7 +94,7 @@ func (s *Storage) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	s.COS.RegisterFlagsWithPrefix(prefix, f)
 	s.CongestionControl.RegisterFlagsWithPrefix(prefix, f)
 
-	s.ObjStoreConf.RegisterFlagsWithPrefix(prefix+"thanos.", f)
+	s.ObjectStore.RegisterFlagsWithPrefix(prefix+"object-store.", f)
 }
 
 type FilesystemConfig struct {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -566,12 +566,11 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 		}
 	}
 
-	if !reflect.DeepEqual(cfg.Common.Storage.ObjStoreConf, defaults.StorageConfig.ObjStoreConf) {
+	if !reflect.DeepEqual(cfg.Common.Storage.ObjectStore, defaults.StorageConfig.ObjectStore) {
 		configsFound++
 
 		applyConfig = func(r *ConfigWrapper) {
-			r.StorageConfig.ThanosObjStore = r.Common.Storage.ThanosObjStore
-			r.StorageConfig.ObjStoreConf = r.Common.Storage.ObjStoreConf
+			r.StorageConfig.ObjectStore = r.Common.Storage.ObjectStore
 			r.StorageConfig.Hedging = r.Common.Storage.Hedging
 		}
 	}

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -571,7 +571,6 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 
 		applyConfig = func(r *ConfigWrapper) {
 			r.StorageConfig.ObjectStore = r.Common.Storage.ObjectStore
-			r.StorageConfig.Hedging = r.Common.Storage.Hedging
 		}
 	}
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/cfg"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 
-	"github.com/grafana/loki/v3/pkg/ruler/rulestore"
 	"github.com/grafana/loki/v3/pkg/ruler/rulestore/local"
 	loki_net "github.com/grafana/loki/v3/pkg/util/net"
 )
@@ -571,10 +570,6 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 		configsFound++
 
 		applyConfig = func(r *ConfigWrapper) {
-			r.Ruler.StoreConfig.ThanosObjStore = r.Common.Storage.ThanosObjStore
-			r.Ruler.StoreConfig.ObjStoreConf = rulestore.Config{
-				Config: r.Common.Storage.ObjStoreConf,
-			}
 			r.StorageConfig.ThanosObjStore = r.Common.Storage.ThanosObjStore
 			r.StorageConfig.ObjStoreConf = r.Common.Storage.ObjStoreConf
 			r.StorageConfig.Hedging = r.Common.Storage.Hedging

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1411,7 +1411,6 @@ func (t *Loki) initCompactor() (services.Service, error) {
 	}
 
 	objectClients := make(map[config.DayTime]client.ObjectClient)
-	metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
 	for _, periodConfig := range t.Cfg.SchemaConfig.Configs {
 		if !config.IsObjectStorageIndex(periodConfig.IndexType) {
 			continue
@@ -1420,7 +1419,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		var objectClient client.ObjectClient
 		var err error
 		if t.Cfg.StorageConfig.ThanosObjStore {
-			objectClient, err = storage.NewObjectClientV2("compactor", periodConfig.ObjectType, t.Cfg.StorageConfig, metrics)
+			objectClient, err = storage.NewObjectClientV2("compactor", periodConfig.ObjectType, t.Cfg.StorageConfig)
 		} else {
 			objectClient, err = storage.NewObjectClient(periodConfig.ObjectType, t.Cfg.StorageConfig, t.ClientMetrics)
 		}
@@ -1435,8 +1434,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 	if t.Cfg.CompactorConfig.RetentionEnabled {
 		if deleteStore := t.Cfg.CompactorConfig.DeleteRequestStore; deleteStore != "" {
 			if t.Cfg.StorageConfig.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				deleteRequestStoreClient, err = storage.NewObjectClientV2("compactor", deleteStore, t.Cfg.StorageConfig, metrics)
+				deleteRequestStoreClient, err = storage.NewObjectClientV2("compactor", deleteStore, t.Cfg.StorageConfig)
 			} else {
 				deleteRequestStoreClient, err = storage.NewObjectClient(deleteStore, t.Cfg.StorageConfig, t.ClientMetrics)
 			}
@@ -1755,8 +1753,7 @@ func (t *Loki) initAnalytics() (services.Service, error) {
 
 	var objectClient client.ObjectClient
 	if t.Cfg.StorageConfig.ThanosObjStore {
-		metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-		objectClient, err = storage.NewObjectClientV2("analytics", period.ObjectType, t.Cfg.StorageConfig, metrics)
+		objectClient, err = storage.NewObjectClientV2("analytics", period.ObjectType, t.Cfg.StorageConfig)
 	} else {
 		objectClient, err = storage.NewObjectClient(period.ObjectType, t.Cfg.StorageConfig, t.ClientMetrics)
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1414,7 +1414,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 
 		var objectClient client.ObjectClient
 		var err error
-		if t.Cfg.StorageConfig.ThanosObjStore {
+		if t.Cfg.StorageConfig.UseThanosObjstore {
 			objectClient, err = storage.NewObjectClientV2("compactor", periodConfig.ObjectType, t.Cfg.StorageConfig)
 		} else {
 			objectClient, err = storage.NewObjectClient(periodConfig.ObjectType, t.Cfg.StorageConfig, t.ClientMetrics)
@@ -1429,7 +1429,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 	var deleteRequestStoreClient client.ObjectClient
 	if t.Cfg.CompactorConfig.RetentionEnabled {
 		if deleteStore := t.Cfg.CompactorConfig.DeleteRequestStore; deleteStore != "" {
-			if t.Cfg.StorageConfig.ThanosObjStore {
+			if t.Cfg.StorageConfig.UseThanosObjstore {
 				deleteRequestStoreClient, err = storage.NewObjectClientV2("compactor", deleteStore, t.Cfg.StorageConfig)
 			} else {
 				deleteRequestStoreClient, err = storage.NewObjectClient(deleteStore, t.Cfg.StorageConfig, t.ClientMetrics)
@@ -1748,7 +1748,7 @@ func (t *Loki) initAnalytics() (services.Service, error) {
 	}
 
 	var objectClient client.ObjectClient
-	if t.Cfg.StorageConfig.ThanosObjStore {
+	if t.Cfg.StorageConfig.UseThanosObjstore {
 		objectClient, err = storage.NewObjectClientV2("analytics", period.ObjectType, t.Cfg.StorageConfig)
 	} else {
 		objectClient, err = storage.NewObjectClient(period.ObjectType, t.Cfg.StorageConfig, t.ClientMetrics)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1237,12 +1237,8 @@ func (t *Loki) initRulerStorage() (_ services.Service, err error) {
 			return nil, err
 		}
 	}
-	overrides, err := validation.NewOverrides(t.Cfg.LimitsConfig, t.TenantLimits)
-	if err != nil {
-		return nil, err
-	}
 
-	t.RulerStorage, err = base_ruler.NewLegacyRuleStore(t.Cfg.Ruler.StoreConfig, overrides, t.Cfg.StorageConfig.Hedging, t.ClientMetrics, ruler.GroupLoader{}, util_log.Logger)
+	t.RulerStorage, err = base_ruler.NewLegacyRuleStore(t.Cfg.Ruler.StoreConfig, t.Cfg.StorageConfig.Hedging, t.ClientMetrics, ruler.GroupLoader{}, util_log.Logger)
 
 	return
 }

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -205,7 +205,7 @@ func buildRuler(t *testing.T, rulerConfig Config, q storage.Querier, clientMetri
 	require.NoError(t, rulerConfig.Validate(log.NewNopLogger()))
 
 	engine, queryable, pusher, logger, overrides, reg := testSetup(t, q)
-	storage, err := NewLegacyRuleStore(rulerConfig.StoreConfig, nil, hedging.Config{}, clientMetrics, promRules.FileLoader{}, log.NewNopLogger())
+	storage, err := NewLegacyRuleStore(rulerConfig.StoreConfig, hedging.Config{}, clientMetrics, promRules.FileLoader{}, log.NewNopLogger())
 	require.NoError(t, err)
 
 	managerFactory := DefaultTenantManagerFactory(rulerConfig, pusher, queryable, engine, reg, constants.Loki)

--- a/pkg/ruler/base/storage.go
+++ b/pkg/ruler/base/storage.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/ibmcloud"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/openstack"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 // RuleStoreConfig configures a rule store.
@@ -44,9 +43,6 @@ type RuleStoreConfig struct {
 	Swift        openstack.SwiftConfig     `yaml:"swift" doc:"description=Configures backend rule storage for Swift."`
 	COS          ibmcloud.COSConfig        `yaml:"cos" doc:"description=Configures backend rule storage for IBM Cloud Object Storage (COS)."`
 	Local        local.Config              `yaml:"local" doc:"description=Configures backend rule storage for a local file system directory."`
-
-	ThanosObjStore bool             `yaml:"thanos_objstore"`
-	ObjStoreConf   rulestore.Config `yaml:"objstore_config"`
 
 	mock rulestore.RuleStore `yaml:"-"`
 }
@@ -86,7 +82,7 @@ func (cfg *RuleStoreConfig) IsDefaults() bool {
 // NewLegacyRuleStore returns a rule store backend client based on the provided cfg.
 // The client used by the function is based a legacy object store clients that shouldn't
 // be used anymore.
-func NewLegacyRuleStore(cfg RuleStoreConfig, cfgProvider bucket.TenantConfigProvider, hedgeCfg hedging.Config, clientMetrics storage.ClientMetrics, loader promRules.GroupLoader, logger log.Logger) (rulestore.RuleStore, error) {
+func NewLegacyRuleStore(cfg RuleStoreConfig, hedgeCfg hedging.Config, clientMetrics storage.ClientMetrics, loader promRules.GroupLoader, logger log.Logger) (rulestore.RuleStore, error) {
 	if cfg.mock != nil {
 		return cfg.mock, nil
 	}
@@ -97,10 +93,6 @@ func NewLegacyRuleStore(cfg RuleStoreConfig, cfgProvider bucket.TenantConfigProv
 
 	var err error
 	var client client.ObjectClient
-
-	if cfg.ThanosObjStore {
-		return NewRuleStore(context.Background(), cfg.ObjStoreConf, cfgProvider, loader, util_log.Logger, prometheus.DefaultRegisterer)
-	}
 
 	switch cfg.Type {
 	case "azure":

--- a/pkg/ruler/base/storage.go
+++ b/pkg/ruler/base/storage.go
@@ -144,8 +144,7 @@ func NewRuleStore(ctx context.Context, cfg rulestore.Config, cfgProvider bucket.
 	if cfg.Backend == local.Name {
 		return local.NewLocalRulesClient(cfg.Local, loader)
 	}
-	metrics := &bucket.Metrics{Registerer: reg}
-	bucketClient, err := bucket.NewClient(ctx, cfg.Config, "ruler-storage", logger, metrics)
+	bucketClient, err := bucket.NewClient(ctx, cfg.Config, "ruler-storage", logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/bucket/client_test.go
+++ b/pkg/storage/bucket/client_test.go
@@ -80,7 +80,7 @@ func TestNewClient(t *testing.T) {
 			require.NoError(t, err)
 
 			// Instance a new bucket client from the config
-			bucketClient, err := NewClient(context.Background(), cfg, "test", util_log.Logger, nil)
+			bucketClient, err := NewClient(context.Background(), cfg, "test", util_log.Logger)
 			require.Equal(t, testData.expectedErr, err)
 
 			if testData.expectedErr == nil {

--- a/pkg/storage/chunk/client/client.go
+++ b/pkg/storage/chunk/client/client.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/thanos-io/objstore"
-
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/series/index"
 )
@@ -32,24 +29,4 @@ type Client interface {
 // Only used by DynamoDB (dynamodbIndexReader and dynamoDBStorageClient)
 type ObjectAndIndexClient interface {
 	PutChunksAndIndex(ctx context.Context, chunks []chunk.Chunk, index index.WriteBatch) error
-}
-
-// Metrics holds metric related configuration for the objstore.
-type Metrics struct {
-	// Registerer is the prometheus registerer that will be used by the objstore
-	// to register bucket metrics.
-	Registerer prometheus.Registerer
-	// BucketMetrics are objstore metrics that are will wrap the bucket.
-	// This field is used to share metrics among buckets with from the same
-	// component.
-	// This should only be set by the function that interfaces with the bucket
-	// package.
-	BucketMetrics *objstore.Metrics
-	// HedgingBucketMetrics are objstore metrics that are will wrap the
-	// heding bucket.
-	// This field is used to share metrics among buckets with from the same
-	// component.
-	// This should only be set by the function that interfaces with the bucket
-	// package.
-	HedgingBucketMetrics *objstore.Metrics
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -295,8 +295,8 @@ type Config struct {
 	DisableBroadIndexQueries bool         `yaml:"disable_broad_index_queries"`
 	MaxParallelGetChunk      int          `yaml:"max_parallel_get_chunk"`
 
-	ThanosObjStore bool          `yaml:"thanos_objstore"`
-	ObjStoreConf   bucket.Config `yaml:"objstore_config"`
+	UseThanosObjstore bool          `yaml:"thanos_objstore"`
+	ObjectStore       bucket.Config `yaml:"object_store"`
 
 	MaxChunkBatchSize   int                       `yaml:"max_chunk_batch_size"`
 	BoltDBShipperConfig boltdb.IndexCfg           `yaml:"boltdb_shipper" doc:"description=Configures storing index in an Object Store (GCS/S3/Azure/Swift/COS/Filesystem) in the form of boltdb files. Required fields only required when boltdb-shipper is defined in config."`
@@ -325,8 +325,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Hedging.RegisterFlagsWithPrefix("store.", f)
 	cfg.CongestionControl.RegisterFlagsWithPrefix("store.", f)
 
-	f.BoolVar(&cfg.ThanosObjStore, "thanos.enable", false, "Enable the thanos.io/objstore to be the backend for object storage")
-	cfg.ObjStoreConf.RegisterFlagsWithPrefix("thanos.", f)
+	f.BoolVar(&cfg.UseThanosObjstore, "use-thanos-objstore", false, "Enable the thanos.io/objstore to be the backend for object storage")
+	cfg.ObjectStore.RegisterFlagsWithPrefix("object-store.", f)
 
 	cfg.IndexQueriesCacheConfig.RegisterFlagsWithPrefix("store.index-cache-read.", "", f)
 	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Cache validity for active index entries. Should be no higher than -ingester.max-chunk-idle.")
@@ -365,7 +365,7 @@ func (cfg *Config) Validate() error {
 	if err := cfg.BloomShipperConfig.Validate(); err != nil {
 		return errors.Wrap(err, "invalid bloom shipper config")
 	}
-	if err := cfg.ObjStoreConf.Validate(); err != nil {
+	if err := cfg.ObjectStore.Validate(); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func NewIndexClient(component string, periodCfg config.PeriodConfig, tableRange 
 
 			var objectClient client.ObjectClient
 			var err error
-			if cfg.ThanosObjStore {
+			if cfg.UseThanosObjstore {
 				objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg)
 			} else {
 				registerer = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, registerer)
@@ -487,7 +487,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 		case types.StorageTypeInMemory:
 			var c client.ObjectClient
 			var err error
-			if cfg.ThanosObjStore {
+			if cfg.UseThanosObjstore {
 				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
@@ -503,7 +503,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 		case types.StorageTypeFileSystem:
 			var c client.ObjectClient
 			var err error
-			if cfg.ThanosObjStore {
+			if cfg.UseThanosObjstore {
 				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
@@ -516,7 +516,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 		case types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCOS, types.StorageTypeAlibabaCloud:
 			var c client.ObjectClient
 			var err error
-			if cfg.ThanosObjStore {
+			if cfg.UseThanosObjstore {
 				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
@@ -532,7 +532,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 		case types.StorageTypeGCS:
 			var c client.ObjectClient
 			var err error
-			if cfg.ThanosObjStore {
+			if cfg.UseThanosObjstore {
 				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
@@ -588,7 +588,7 @@ func NewTableClient(component, name string, periodCfg config.PeriodConfig, cfg C
 	case util.StringsContain(types.SupportedIndexTypes, name):
 		var objectClient client.ObjectClient
 		var err error
-		if cfg.ThanosObjStore {
+		if cfg.UseThanosObjstore {
 			objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg)
 		} else {
 			objectClient, err = NewObjectClient(periodCfg.ObjectType, cfg, cm)
@@ -733,8 +733,8 @@ func internalNewObjectClient(component, name string, cfg Config, clientMetrics C
 		if cfg.CongestionControl.Enabled {
 			gcsCfg.EnableRetries = false
 		}
-		if cfg.ThanosObjStore {
-			return gcp.NewGCSThanosObjectClient(context.Background(), cfg.ObjStoreConf, component, util_log.Logger, cfg.Hedging)
+		if cfg.UseThanosObjstore {
+			return gcp.NewGCSThanosObjectClient(context.Background(), cfg.ObjectStore, component, util_log.Logger, cfg.Hedging)
 		}
 		return gcp.NewGCSObjectClient(context.Background(), gcsCfg, cfg.Hedging)
 

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -407,8 +407,7 @@ func NewIndexClient(component string, periodCfg config.PeriodConfig, tableRange 
 			var objectClient client.ObjectClient
 			var err error
 			if cfg.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg, metrics)
+				objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg)
 			} else {
 				registerer = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, registerer)
 				objectClient, err = NewObjectClient(periodCfg.ObjectType, cfg, cm)
@@ -489,8 +488,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 			var c client.ObjectClient
 			var err error
 			if cfg.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				c, err = NewObjectClientV2(component, name, cfg, metrics)
+				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
 			}
@@ -506,8 +504,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 			var c client.ObjectClient
 			var err error
 			if cfg.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				c, err = NewObjectClientV2(component, name, cfg, metrics)
+				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
 			}
@@ -520,8 +517,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 			var c client.ObjectClient
 			var err error
 			if cfg.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				c, err = NewObjectClientV2(component, name, cfg, metrics)
+				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
 			}
@@ -537,8 +533,7 @@ func NewChunkClient(component, name string, cfg Config, schemaCfg config.SchemaC
 			var c client.ObjectClient
 			var err error
 			if cfg.ThanosObjStore {
-				metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-				c, err = NewObjectClientV2(component, name, cfg, metrics)
+				c, err = NewObjectClientV2(component, name, cfg)
 			} else {
 				c, err = NewObjectClient(name, cfg, clientMetrics)
 			}
@@ -594,8 +589,7 @@ func NewTableClient(component, name string, periodCfg config.PeriodConfig, cfg C
 		var objectClient client.ObjectClient
 		var err error
 		if cfg.ThanosObjStore {
-			metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-			objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg, metrics)
+			objectClient, err = NewObjectClientV2(component, periodCfg.ObjectType, cfg)
 		} else {
 			objectClient, err = NewObjectClient(periodCfg.ObjectType, cfg, cm)
 		}
@@ -654,10 +648,7 @@ func (c *ClientMetrics) Unregister() {
 
 // NewObjectClient makes a new StorageClient with the prefix in the front.
 func NewObjectClient(name string, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
-	metrics := &client.Metrics{
-		Registerer: prometheus.DefaultRegisterer,
-	}
-	actual, err := internalNewObjectClient("", name, cfg, clientMetrics, metrics)
+	actual, err := internalNewObjectClient("", name, cfg, clientMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -671,11 +662,10 @@ func NewObjectClient(name string, cfg Config, clientMetrics ClientMetrics) (clie
 }
 
 // NewObjectClient makes a new StorageClient with the prefix in the front.
-func NewObjectClientV2(component, name string, cfg Config, metrics *client.Metrics) (client.ObjectClient, error) {
-	// Statify internalNewObjectClient signature to be removed once the old objstore is removed
+func NewObjectClientV2(component, name string, cfg Config) (client.ObjectClient, error) {
+	// TODO: Statify internalNewObjectClient signature to be removed once the old objstore is removed
 	clientMetrics := ClientMetrics{}
-
-	actual, err := internalNewObjectClient(component, name, cfg, clientMetrics, metrics)
+	actual, err := internalNewObjectClient(component, name, cfg, clientMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -689,7 +679,7 @@ func NewObjectClientV2(component, name string, cfg Config, metrics *client.Metri
 }
 
 // internalNewObjectClient makes the underlying StorageClient of the desired types.
-func internalNewObjectClient(component, name string, cfg Config, clientMetrics ClientMetrics, metrics *client.Metrics) (client.ObjectClient, error) {
+func internalNewObjectClient(component, name string, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
 	var (
 		namedStore string
 		storeType  = name
@@ -744,7 +734,7 @@ func internalNewObjectClient(component, name string, cfg Config, clientMetrics C
 			gcsCfg.EnableRetries = false
 		}
 		if cfg.ThanosObjStore {
-			return gcp.NewGCSThanosObjectClient(context.Background(), cfg.ObjStoreConf, component, util_log.Logger, cfg.Hedging, metrics)
+			return gcp.NewGCSThanosObjectClient(context.Background(), cfg.ObjStoreConf, component, util_log.Logger, cfg.Hedging)
 		}
 		return gcp.NewGCSObjectClient(context.Background(), gcsCfg, cfg.Hedging)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -286,7 +286,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 
 		var objectClient client.ObjectClient
 		var err error
-		if s.cfg.ThanosObjStore {
+		if s.cfg.UseThanosObjstore {
 			objectClient, err = NewObjectClientV2(component, p.ObjectType, s.cfg)
 		} else {
 			objectClient, err = NewObjectClient(p.ObjectType, s.cfg, s.clientMetrics)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -193,7 +193,6 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 }
 
 func (s *LokiStore) init() error {
-	metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
 	for i, p := range s.schemaCfg.Configs {
 		p := p
 		chunkClient, err := s.chunkClientForPeriod(p)
@@ -209,7 +208,7 @@ func (s *LokiStore) init() error {
 		if i < len(s.schemaCfg.Configs)-1 {
 			periodEndTime = config.DayTime{Time: s.schemaCfg.Configs[i+1].From.Time.Add(-time.Millisecond)}
 		}
-		w, idx, stop, err := s.storeForPeriod(p, p.GetIndexTableNumberRange(periodEndTime), chunkClient, f, metrics)
+		w, idx, stop, err := s.storeForPeriod(p, p.GetIndexTableNumberRange(periodEndTime), chunkClient, f)
 		if err != nil {
 			return err
 		}
@@ -265,7 +264,7 @@ func shouldUseIndexGatewayClient(cfg indexshipper.Config) bool {
 	return true
 }
 
-func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher, metrics *client.Metrics) (stores.ChunkWriter, index.ReaderWriter, func(), error) {
+func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher) (stores.ChunkWriter, index.ReaderWriter, func(), error) {
 	component := fmt.Sprintf("index-store-%s-%s", p.IndexType, p.From.String())
 	indexClientReg := prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, s.registerer)
 	indexClientLogger := log.With(s.logger, "index-store", fmt.Sprintf("%s-%s", p.IndexType, p.From.String()))
@@ -288,7 +287,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 		var objectClient client.ObjectClient
 		var err error
 		if s.cfg.ThanosObjStore {
-			objectClient, err = NewObjectClientV2(component, p.ObjectType, s.cfg, metrics)
+			objectClient, err = NewObjectClientV2(component, p.ObjectType, s.cfg)
 		} else {
 			objectClient, err = NewObjectClient(p.ObjectType, s.cfg, s.clientMetrics)
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -333,12 +333,11 @@ func NewBloomStore(
 		}
 	}
 
-	metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
 	for _, periodicConfig := range periodicConfigs {
 		var objectClient client.ObjectClient
 		var err error
 		if storageConfig.ThanosObjStore {
-			objectClient, err = storage.NewObjectClientV2("bloom-store", periodicConfig.ObjectType, storageConfig, metrics)
+			objectClient, err = storage.NewObjectClientV2("bloom-store", periodicConfig.ObjectType, storageConfig)
 		} else {
 			objectClient, err = storage.NewObjectClient(periodicConfig.ObjectType, storageConfig, clientMetrics)
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -336,7 +336,7 @@ func NewBloomStore(
 	for _, periodicConfig := range periodicConfigs {
 		var objectClient client.ObjectClient
 		var err error
-		if storageConfig.ThanosObjStore {
+		if storageConfig.UseThanosObjstore {
 			objectClient, err = storage.NewObjectClientV2("bloom-store", periodicConfig.ObjectType, storageConfig)
 		} else {
 			objectClient, err = storage.NewObjectClient(periodicConfig.ObjectType, storageConfig, clientMetrics)

--- a/pkg/tool/audit/audit.go
+++ b/pkg/tool/audit/audit.go
@@ -54,7 +54,7 @@ func GetObjectClient(cfg Config) (client.ObjectClient, error) {
 	periodCfg := cfg.SchemaConfig.Configs[len(cfg.SchemaConfig.Configs)-1] // only check the last period.
 	var objClient client.ObjectClient
 	var err error
-	if cfg.StorageConfig.ThanosObjStore {
+	if cfg.StorageConfig.UseThanosObjstore {
 		objClient, err = storage.NewObjectClientV2("audit", periodCfg.ObjectType, cfg.StorageConfig)
 	} else {
 		objClient, err = storage.NewObjectClient(periodCfg.ObjectType, cfg.StorageConfig, storage.NewClientMetrics())

--- a/pkg/tool/audit/audit.go
+++ b/pkg/tool/audit/audit.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	progressbar "github.com/schollz/progressbar/v3"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
@@ -56,8 +55,7 @@ func GetObjectClient(cfg Config) (client.ObjectClient, error) {
 	var objClient client.ObjectClient
 	var err error
 	if cfg.StorageConfig.ThanosObjStore {
-		metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-		objClient, err = storage.NewObjectClientV2("audit", periodCfg.ObjectType, cfg.StorageConfig, metrics)
+		objClient, err = storage.NewObjectClientV2("audit", periodCfg.ObjectType, cfg.StorageConfig)
 	} else {
 		objClient, err = storage.NewObjectClient(periodCfg.ObjectType, cfg.StorageConfig, storage.NewClientMetrics())
 	}

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -27,8 +27,7 @@ func main() {
 
 	var objectClient client.ObjectClient
 	if conf.StorageConfig.ThanosObjStore {
-		metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-		objectClient, err = storage.NewObjectClientV2("index-analyzer", periodCfg.ObjectType, conf.StorageConfig, metrics)
+		objectClient, err = storage.NewObjectClientV2("index-analyzer", periodCfg.ObjectType, conf.StorageConfig)
 	} else {
 		objectClient, err = storage.NewObjectClient(periodCfg.ObjectType, conf.StorageConfig, clientMetrics)
 	}

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -26,7 +26,7 @@ func main() {
 	helpers.ExitErr("find period config for bucket", err)
 
 	var objectClient client.ObjectClient
-	if conf.StorageConfig.ThanosObjStore {
+	if conf.StorageConfig.UseThanosObjstore {
 		objectClient, err = storage.NewObjectClientV2("index-analyzer", periodCfg.ObjectType, conf.StorageConfig)
 	} else {
 		objectClient, err = storage.NewObjectClient(periodCfg.ObjectType, conf.StorageConfig, clientMetrics)

--- a/tools/tsdb/migrate-versions/main.go
+++ b/tools/tsdb/migrate-versions/main.go
@@ -102,8 +102,7 @@ func migrateTables(pCfg config.PeriodConfig, storageCfg storage.Config, clientMe
 	var objClient client.ObjectClient
 	var err error
 	if storageCfg.ThanosObjStore {
-		metrics := &client.Metrics{Registerer: prometheus.DefaultRegisterer}
-		objClient, err = storage.NewObjectClientV2("tables-migration-tool", pCfg.ObjectType, storageCfg, metrics)
+		objClient, err = storage.NewObjectClientV2("tables-migration-tool", pCfg.ObjectType, storageCfg)
 	} else {
 		objClient, err = storage.NewObjectClient(pCfg.ObjectType, storageCfg, clientMetrics)
 	}

--- a/tools/tsdb/migrate-versions/main.go
+++ b/tools/tsdb/migrate-versions/main.go
@@ -101,7 +101,7 @@ func main() {
 func migrateTables(pCfg config.PeriodConfig, storageCfg storage.Config, clientMetrics storage.ClientMetrics, tableRange config.TableRange) error {
 	var objClient client.ObjectClient
 	var err error
-	if storageCfg.ThanosObjStore {
+	if storageCfg.UseThanosObjstore {
 		objClient, err = storage.NewObjectClientV2("tables-migration-tool", pCfg.ObjectType, storageCfg)
 	} else {
 		objClient, err = storage.NewObjectClient(pCfg.ObjectType, storageCfg, clientMetrics)


### PR DESCRIPTION
**What this PR does / why we need it**:
- use a global thanos metric.
- remove ruler changes, will be added in a separate pr
- rename configs

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
